### PR TITLE
Django 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
-        django-version: ["3.1", "3.2", "main"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        django-version: ["3.2", "4.0", "main"]
+        exclude:
+          - python-version: "3.7"
+            django-version: "4.0"
+          - python-version: "3.7"
+            django-version: "main"
 
     steps:
       - name: Checkout

--- a/guest_user/__init__.py
+++ b/guest_user/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "guest_user.apps.GuestUserConfig"

--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,19 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 DJANGO =
-    3.1: dj31
     3.2: dj32
+    4.0: dj40
     main: djmain
 
 [tox]
 skipsdist = true
 envlist =
-    py{37,38,39}-dj{31,32}
-    py{38,39}-djmain
+    py{37,38,39,310}-dj32
+    py{38,39,310}-dj{40,main}
 
 [testenv]
 ignore_outcome =
@@ -23,8 +24,8 @@ deps =
     pytest
     pytest-django
     django-allauth
-    dj31: django>=3.1,<3.2
     dj32: django>=3.2,<3.3
+    dj40: django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz
 commands =
     pytest


### PR DESCRIPTION
This PR:

* removes one last feature that was deprecated in Django 4.0 (which silences a warning from this package when running tests)
* adds Django 4.0 to the test matrix
* removes Django 3.1 from the test matrix (since this is EOL in just a few days)
* adds Python 3.10 to the test matrix