### PR TITLE
Update convert_form.html to resolve NoReverseMatch error for django 4…

### DIFF
--- a/guest_user/app_settings.py
+++ b/guest_user/app_settings.py
@@ -130,7 +130,7 @@ class AppSettings:
         :default: ``"guest_user_convert_success"``
 
         """
-        return self.get("CONVERT_REDIRECT_URL", "guest_user_convert_success")
+        return self.get("CONVERT_REDIRECT_URL", "core:guest_user_convert_success")
 
     @property
     def REQUIRED_ANON_URL(self) -> str:

--- a/guest_user/templates/guest_user/convert_form.html
+++ b/guest_user/templates/guest_user/convert_form.html
@@ -5,7 +5,7 @@
   <title>Convert</title>
 </head>
 <body>
-  <form action="{% url "guest_user_convert" %}" method="POST">
+  <form action="{% url "core:guest_user_convert" %}" method="POST">
     {% csrf_token %}
 
     {{ form.as_p }}


### PR DESCRIPTION
….2.*+

NoReverseMatch at /convert/

Reverse for 'guest_user_convert' not found. 'guest_user_convert' is not a valid view function or pattern name.

Updated convert_form.html to work with django versions 4.2.*+ and resolve the aforementioned error.